### PR TITLE
fix #13: dates with LT/LTE/GT/GTE/IN/BETWEEN

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "date-fns": "^2.26.0",
     "typeorm": "^0.2.25"
   }
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Like, IsNull, LessThan, LessThanOrEqual, MoreThan, In, Between, MoreThanOrEqual, Not } from 'typeorm';
+import { Between, In, IsNull, LessThan, LessThanOrEqual, Like, MoreThan, MoreThanOrEqual, Not } from 'typeorm';
 import { QueryBuilder } from '../index';
 
 describe('QueryBuilder test', () => {
@@ -150,6 +150,9 @@ describe('QueryBuilder test', () => {
       it('testing between operator', () => {
         expect(qb.build({ filter: 'id||$between||1,3' })).toEqual({ where: [{ id: Between(1, 3) }] });
       });
+      it('testing gte operator with date', () => {
+        expect(qb.build({ filter: 'date||$gte||2021-01-01' })).toEqual({ where: [{ date: MoreThanOrEqual('2021-01-01') }] });
+      });      
     });
     describe('testing join', () => {
       it('should return empty object if join string not provided', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { isMatch } from 'date-fns';
 import { Between, In, IsNull, LessThan, LessThanOrEqual, Like, MoreThan, MoreThanOrEqual, Not } from 'typeorm';
 
 export interface IOptionsObject {
@@ -40,6 +41,10 @@ export interface IQueryObject {
 }
 interface ILooseObject {
   [key: string]: any;
+}
+enum EDateType {
+  Date = "yyyy-MM-dd",
+  Datetime = "yyyy-MM-dd HH:MM:ss"
 }
 
 export class QueryBuilder {
@@ -172,28 +177,32 @@ export class QueryBuilder {
         obj[field] = IsNull();
         break;
       case this.options.LT:
-        obj[field] = LessThan(+value);
+        obj[field] = LessThan(this.parseDateOrNumber(value));
         break;
       case this.options.LTE:
-        obj[field] = LessThanOrEqual(+value);
+        obj[field] = LessThanOrEqual(this.parseDateOrNumber(value));
         break;
       case this.options.GT:
-        obj[field] = MoreThan(+value);
+        obj[field] = MoreThan(this.parseDateOrNumber(value));
         break;
       case this.options.GTE:
-        obj[field] = MoreThanOrEqual(+value);
+        obj[field] = MoreThanOrEqual(this.parseDateOrNumber(value));
         break;
       case this.options.IN:
         obj[field] = In(value.split(this.options.VALUE_DELIMITER as string));
         break;
       case this.options.BETWEEN:
         const rangeValues = value.split(this.options.VALUE_DELIMITER as string);
-        obj[field] = Between(+rangeValues[0], +rangeValues[1]);
+        obj[field] = Between(this.parseDateOrNumber(rangeValues[0]), this.parseDateOrNumber(rangeValues[1]));
         break;
     }
     if (notOperator) {
       obj[field] = Not(obj[field]);
     }
     return obj;
+  }
+
+  private parseDateOrNumber(value: string) {
+    return (isMatch(value, EDateType.Date) || isMatch(value, EDateType.Datetime)) ? value : +value;
   }
 }


### PR DESCRIPTION
I created a little function that checks if the value is a valid date using date-fns (based on [this thread](https://github.com/typeorm/typeorm/issues/2286) from typeorm). Added one test with $gte.

One point to consider is that, even if my approach was to use date/datetime, the implementation will still fail if another kind of string is sent. I know some databases support the same operators on strings (maybe all?), but knowing for sure if a number formatted string shall be converted or not would add complexity, so I kept this way.